### PR TITLE
Bump rexml from 3.2.8 to 3.3.3 in /docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -225,8 +225,8 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.3)
+      strscan
     rouge (3.23.0)
     ruby-enum (0.8.0)
       i18n


### PR DESCRIPTION
### Description

In this pull request, the version of the `rexml` gem in the `Gemfile.lock` is being updated from `3.2.8` to `3.3.3`.

The changes in this PR include:
- Updating the version of the `rexml` gem from `3.2.8` to `3.3.3` in the `Gemfile.lock` file.